### PR TITLE
Fix chapter time UTC shifting after RH restart

### DIFF
--- a/custom_plugins/youtube_chapters/__init__.py
+++ b/custom_plugins/youtube_chapters/__init__.py
@@ -119,8 +119,8 @@ class YouTubeChapters:
                     )
                     self.chapters = [
                         (
-                            datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").astimezone(
-                                timezone.utc
+                            datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").replace(
+                                tzinfo=timezone.utc
                             ),
                             heat,
                         )


### PR DESCRIPTION
After a RotorHazard restart, existing chapters were not loaded correctly into the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
	- Updated the process for converting chapter timestamps to enhance consistency and accuracy when handling chapter data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->