### PR TITLE
⬆️ Update RHFest integration to v3.2.0

### DIFF
--- a/.github/workflows/rhfest.yaml
+++ b/.github/workflows/rhfest.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v7.0.1
       - name: 🚀 Run RHFest validation
-        uses: docker://ghcr.io/rotorhazard/rhfest-action:v3.1.0
+        uses: RotorHazard/rhfest-action@v3.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,9 +55,9 @@ repos:
         types: [text]
         entry: uv run trailing-whitespace-fixer
         stages: [commit, push, manual]
+  - repo: https://github.com/RotorHazard/rhfest-action
+    rev: v3.2.0
+    hooks:
       - id: rhfest
         name: 🎉 Check RHFest
-        language: system
-        entry: docker
-        args: ["run", "--rm", "--pull=always", "-v", ".:/repo", "ghcr.io/rotorhazard/rhfest-action:latest"]
-        pass_filenames: false
+        stages: [pre-commit, pre-push, manual]


### PR DESCRIPTION
## Summary

- update the RHFest workflow from the v3.1.0 container image to the repository Action at v3.2.0
- replace the local Docker command with the official RHFest pre-commit hook
- run RHFest during pre-commit, pre-push, and manual stages

## Testing

- validated the pre-commit configuration
- ran all existing repository hooks
- fetched, built, and ran the published RHFest v3.2.0 hook successfully
- RHFest validation passed for the plugin